### PR TITLE
fix file naming for automated creation of deb packages

### DIFF
--- a/rdfunit-validate/pom.xml
+++ b/rdfunit-validate/pom.xml
@@ -179,7 +179,7 @@
                                 </goals>
                                 <configuration>
                                     <verbose>true</verbose>
-                                    <deb>${basedir}/target/${project.build.finalName}-${project.version}.deb</deb>
+                                    <deb>${basedir}/target/${project.build.finalName}_${project.version}.deb</deb>
                                     <dataSet>
                                         <data>
                                             <src>${basedir}/target/rdfunit-cli.jar</src>
@@ -212,7 +212,7 @@
                                     </dataSet>
                                     <changesIn>${basedir}/debian/CHANGES.txt</changesIn>
                                     <changesSave>${basedir}/debian/CHANGES.txt</changesSave>
-                                    <changesOut>${project.build.directory}/${project.build.finalName}-${project.version}.changes
+                                    <changesOut>${project.build.directory}/${project.build.finalName}_${project.version}.changes
                                     </changesOut>
                                 </configuration>
                             </execution>

--- a/rdfunit-webdemo/pom.xml
+++ b/rdfunit-webdemo/pom.xml
@@ -367,7 +367,7 @@
                                 </goals>
                                 <configuration>
                                     <verbose>true</verbose>
-                                    <deb>${basedir}/target/${project.build.finalName}-${project.version}.deb</deb>
+                                    <deb>${basedir}/target/${project.build.finalName}_${project.version}.deb</deb>
                                     <dataSet>
                                         <data>
                                             <src>${project.build.directory}/${project.build.finalName}.war</src>
@@ -380,7 +380,7 @@
                                     </dataSet>
                                     <changesIn>${basedir}/debian/CHANGES.txt</changesIn>
                                     <changesSave>${basedir}/debian/CHANGES.txt</changesSave>
-                                    <changesOut>${project.build.directory}/${project.build.finalName}-${project.version}.changes</changesOut>
+                                    <changesOut>${project.build.directory}/${project.build.finalName}_${project.version}.changes</changesOut>
                                 </configuration>
                             </execution>
                         </executions>


### PR DESCRIPTION
For a successful upload to the nightly repo, the version number in the created .changes files must practice with an underscore.
