### PR TITLE
create package files that match Debian naming conventions

### DIFF
--- a/rdfunit-validate/pom.xml
+++ b/rdfunit-validate/pom.xml
@@ -179,7 +179,6 @@
                                 </goals>
                                 <configuration>
                                     <verbose>true</verbose>
-                                    <deb>${basedir}/target/${project.build.finalName}_${project.version}.deb</deb>
                                     <dataSet>
                                         <data>
                                             <src>${basedir}/target/rdfunit-cli.jar</src>
@@ -212,8 +211,6 @@
                                     </dataSet>
                                     <changesIn>${basedir}/debian/CHANGES.txt</changesIn>
                                     <changesSave>${basedir}/debian/CHANGES.txt</changesSave>
-                                    <changesOut>${project.build.directory}/${project.build.finalName}_${project.version}.changes
-                                    </changesOut>
                                 </configuration>
                             </execution>
                         </executions>

--- a/rdfunit-webdemo/pom.xml
+++ b/rdfunit-webdemo/pom.xml
@@ -367,7 +367,6 @@
                                 </goals>
                                 <configuration>
                                     <verbose>true</verbose>
-                                    <deb>${basedir}/target/${project.build.finalName}_${project.version}.deb</deb>
                                     <dataSet>
                                         <data>
                                             <src>${project.build.directory}/${project.build.finalName}.war</src>
@@ -380,7 +379,6 @@
                                     </dataSet>
                                     <changesIn>${basedir}/debian/CHANGES.txt</changesIn>
                                     <changesSave>${basedir}/debian/CHANGES.txt</changesSave>
-                                    <changesOut>${project.build.directory}/${project.build.finalName}_${project.version}.changes</changesOut>
                                 </configuration>
                             </execution>
                         </executions>


### PR DESCRIPTION
fixes deb packaging output files to match naming convention (must not have "-" after version number)
