### PR TITLE
Maven build: small fix to make shaded, self-contained jars working again

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -375,11 +375,12 @@
                     <artifactId>lombok-maven-plugin</artifactId>
                     <version>1.16.18.0</version>
                 </plugin>
-
+                <plugin>
+                    <artifactId>maven-shade-plugin</artifactId>
+                    <version>3.1.0</version>
+                </plugin>
             </plugins>
-
         </pluginManagement>
-
 
     </build>
 

--- a/rdfunit-validate/pom.xml
+++ b/rdfunit-validate/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <artifactId>rdfunit-parent</artifactId>
@@ -97,12 +98,11 @@
                     <httpConnector>
                         <port>8787</port>
                     </httpConnector>
-                    <stopKey />
-                    <stopPort />
+                    <stopKey/>
+                    <stopPort/>
                 </configuration>
             </plugin>
         </plugins>
-
     </build>
 
 
@@ -116,10 +116,6 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-shade-plugin</artifactId>
-                        <version>3.0.0</version>
-                        <configuration>
-                            <!-- put your configurations here -->
-                        </configuration>
                         <executions>
                             <execution>
                                 <phase>package</phase>
@@ -128,9 +124,12 @@
                                 </goals>
                                 <configuration>
                                     <transformers>
-                                        <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                        <transformer
+                                                implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                             <mainClass>org.aksw.rdfunit.validate.cli.ValidateCLI</mainClass>
                                         </transformer>
+                                        <transformer
+                                                implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                                     </transformers>
                                     <filters>
                                         <filter>
@@ -193,6 +192,48 @@
                                     </dataSet>
                                     <changesIn>${basedir}/debian/CHANGES.txt</changesIn>
                                     <changesSave>${basedir}/debian/CHANGES.txt</changesSave>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>cli-standalone</id>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-shade-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>shade</goal>
+                                </goals>
+                                <configuration>
+                                    <shadedArtifactAttached>true</shadedArtifactAttached>
+                                    <shadedClassifierName>standalone</shadedClassifierName>
+                                    <transformers>
+                                        <transformer
+                                                implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                            <mainClass>org.aksw.rdfunit.validate.cli.ValidateCLI</mainClass>
+                                        </transformer>
+                                        <transformer
+                                                implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                                    </transformers>
+                                    <filters>
+                                        <filter>
+                                            <artifact>*:*</artifact>
+                                            <excludes>
+                                                <exclude>META-INF/*.SF</exclude>
+                                                <exclude>META-INF/*.DSA</exclude>
+                                                <exclude>META-INF/*.RSA</exclude>
+                                            </excludes>
+                                        </filter>
+                                    </filters>
                                 </configuration>
                             </execution>
                         </executions>


### PR DESCRIPTION
With an update to the recent Jena version, the shaded jars stopped to work, since Jena now uses the [ServiceLocator](https://docs.oracle.com/javase/7/docs/api/java/util/ServiceLoader.html), but the corresponding implementor declarations are not copied over into the shaded jar file.

This PR fixes this and also introduces a new maven profile to just create an additional shaded, self-contained, executable jar file without the deb package. Such jars can be handy to hand over to let people quickly try RDFUnit in environments where git & maven is not readily available (e.g. Docker images that are intended to keep small in size and layers).