### PR TITLE
refactored loading of schemaDecl.csv so that the file can be overridden

### DIFF
--- a/data/README.md
+++ b/data/README.md
@@ -1,3 +1,3 @@
-Patterns & AutoGenerators are moved to resources (rdfunit-core/src/main/resources/org/aksw/rdfunit/configuration/*)
+Patterns & AutoGenerators are moved to resources (rdfunit-model/src/main/resources/org/aksw/rdfunit/configuration/*)
 
 If you want to override the default files place the modified files in this folder

--- a/data/autoGeneratorsOWL.ttl.default
+++ b/data/autoGeneratorsOWL.ttl.default
@@ -1,4 +1,4 @@
 #
 # Rename this file to testAutoGenerators.ttl in order to override the java resource located in
-# rdfunit-core/src/main/resources/org/aksw/rdfunit/configuration/autoGeneratorsOWL.ttl
+# rdfunit-model/src/main/resources/org/aksw/rdfunit/configuration/autoGeneratorsOWL.ttl
 #

--- a/data/patterns.ttl.default
+++ b/data/patterns.ttl.default
@@ -1,4 +1,4 @@
 #
 # Rename this file to patterns.ttl in order to override the java resource located in
-# rdfunit-core/src/main/resources/org/aksw/rdfunit/configuration/patterns.ttl
+# rdfunit-model/src/main/resources/org/aksw/rdfunit/configuration/patterns.ttl
 #

--- a/data/schemaDecl.csv.default
+++ b/data/schemaDecl.csv.default
@@ -1,0 +1,6 @@
+#
+# Rename this file to patterns.ttl in order to override the java resource located in
+# rdfunit-model/src/main/resources/org/aksw/rdfunit/configuration/schemaDecl.csv
+#
+# expected columns:
+# prefix,URI,URL(if URI does not dereference)

--- a/rdfunit-core/src/main/java/org/aksw/rdfunit/sources/CacheUtils.java
+++ b/rdfunit-core/src/main/java/org/aksw/rdfunit/sources/CacheUtils.java
@@ -63,7 +63,8 @@ public final class CacheUtils {
     }
 
     private static String getFile(String testFolder, Source source, String type, String sourceType) {
-        return testFolder + sourceType + "/" + UriToPathUtils.getCacheFolderForURI(source.getUri()) + source.getPrefix() + "." + type + "." + sourceType + ".ttl";
+        return testFolder + sourceType + "/" + UriToPathUtils.getCacheFolderForURI(source.getUri()) +
+                source.getPrefix() + "." + type + "." + sourceType + ".ttl";
     }
 
 }

--- a/rdfunit-validate/src/main/java/org/aksw/rdfunit/validate/cli/ValidateCLI.java
+++ b/rdfunit-validate/src/main/java/org/aksw/rdfunit/validate/cli/ValidateCLI.java
@@ -67,9 +67,6 @@ public final class ValidateCLI {
         if (!commandLine.hasOption('v')) { // explicitely do not use LOV
             RDFUnitUtils.fillSchemaServiceFromLOV();
         }
-        //TODO hack until we fix this, configuration tries to load schemas so they must be initialized before
-        RDFUnitUtils.fillSchemaServiceFromFile(ValidateCLI.class.getResourceAsStream("/org/aksw/rdfunit/configuration/schemaDecl.csv"));
-        //RDFUnitUtils.fillSchemaServiceFromFile(configuration.getDataFolder() + "schemaDecl.csv");
 
         RDFUnitConfiguration configuration = null;
         try {

--- a/rdfunit-validate/src/main/java/org/aksw/rdfunit/validate/utils/ValidateUtils.java
+++ b/rdfunit-validate/src/main/java/org/aksw/rdfunit/validate/utils/ValidateUtils.java
@@ -4,11 +4,17 @@ import org.aksw.rdfunit.RDFUnitConfiguration;
 import org.aksw.rdfunit.enums.TestCaseExecutionType;
 import org.aksw.rdfunit.exceptions.UndefinedSchemaException;
 import org.aksw.rdfunit.exceptions.UndefinedSerializationException;
+import org.aksw.rdfunit.utils.RDFUnitUtils;
 import org.aksw.rdfunit.validate.ParameterException;
+import org.aksw.rdfunit.validate.cli.ValidateCLI;
 import org.apache.commons.cli.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
 
@@ -102,6 +108,18 @@ public final class ValidateUtils {
 
         setDumpOrSparqlEndpoint(commandLine, configuration);
 
+        try (InputStream customSchemaDeclStream =
+                     Files.newInputStream(Paths.get(configuration.getDataFolder() + "schemaDecl.csv"))){
+            RDFUnitUtils.fillSchemaServiceFromFile(customSchemaDeclStream);
+        } catch(NoSuchFileException nsfe) {
+            RDFUnitUtils.fillSchemaServiceFromFile(
+                    ValidateCLI.class.getResourceAsStream("/org/aksw/rdfunit/configuration/schemaDecl.csv"));
+        } catch(Exception e) {
+            LOGGER.warn("Loading custom scheme declarations failed.\n" +
+                    "Falling back to bundled declarations in classpath due to", e);
+            RDFUnitUtils.fillSchemaServiceFromFile(
+                    ValidateCLI.class.getResourceAsStream("/org/aksw/rdfunit/configuration/schemaDecl.csv"));
+        }
 
         setSchemas(commandLine, configuration);
         setEnrichedSchemas(commandLine, configuration);


### PR DESCRIPTION
This PR removes the 'hack' of loading the schema declaration CSV very early in CLI mode and always from the classpath. With these changes, `schemaDecl.csv` can be overridden with custom versions from the data directory as it is already possible many other config files for RDFUnit
