### PR TITLE
Minor update to the schema exclude order for the CLI case

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -388,7 +388,6 @@
                 </plugin>
             </plugins>
         </pluginManagement>
-
     </build>
 
     <reporting>

--- a/rdfunit-core/src/main/java/org/aksw/rdfunit/RDFUnitConfiguration.java
+++ b/rdfunit-core/src/main/java/org/aksw/rdfunit/RDFUnitConfiguration.java
@@ -160,17 +160,19 @@ public class RDFUnitConfiguration {
     }
 
     public Collection<SchemaSource> getAllSchemata() {
-        List<SchemaSource> allSchemas = new ArrayList<>();
+        Set<SchemaSource> allSchemas = new HashSet<>();
         if (this.schemas != null) {
             allSchemas.addAll(this.schemas);
         }
         if (this.enrichedSchema != null) {
             allSchemas.add(this.enrichedSchema);
         }
+        Set<SchemaSource> excludeable = new HashSet<>(this.excludeSchemata);
+        excludeable.removeAll(allSchemas);      //overriding excludes if explicitly provided
         if(augmentWithOwlImports){
-            List<SchemaSource> imports = RDFUnitUtils.augmentWithOwlImports(allSchemas);
-            imports.forEach(i -> {if(!allSchemas.contains(i)) allSchemas.add(i);});
+            allSchemas.addAll(RDFUnitUtils.augmentWithOwlImports(allSchemas));
         }
+        allSchemas.removeAll(excludeable);
         return allSchemas;
     }
 

--- a/rdfunit-core/src/main/java/org/aksw/rdfunit/utils/RDFUnitUtils.java
+++ b/rdfunit-core/src/main/java/org/aksw/rdfunit/utils/RDFUnitUtils.java
@@ -138,7 +138,7 @@ public final class RDFUnitUtils {
         return collection.stream().findFirst();
     }
 
-    public static List<SchemaSource> augmentWithOwlImports(List<SchemaSource> originalSources) {
+    public static List<SchemaSource> augmentWithOwlImports(Set<SchemaSource> originalSources) {
 
         ImmutableList.Builder<SchemaSource> augmentedSources = ImmutableList.builder();
         augmentedSources.addAll(originalSources);

--- a/rdfunit-validate/pom.xml
+++ b/rdfunit-validate/pom.xml
@@ -101,6 +101,36 @@
                     <stopPort />
                 </configuration>
             </plugin>
+            <plugin>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>3.0.2</version>
+                <executions>
+                    <execution>
+                        <id>copy-resources-local</id>
+                        <!-- This is needed to run the ui locally -->
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${basedir}/src/main/resources</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>../rdfunit-commons/src/main/resources</directory>
+                                    <includes>
+                                        <include>**/*</include>
+                                    </includes>
+                                    <excludes>
+                                        <exclude>**/*.md</exclude>
+                                        <exclude>**/*.txt</exclude>
+                                    </excludes>
+                                </resource>
+                            </resources>
+                            <overwrite>true</overwrite>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 
@@ -201,8 +231,7 @@
 
             <build>
                 <plugins>
-
-						<plugin>
+                    <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-shade-plugin</artifactId>
                         <executions>

--- a/rdfunit-validate/src/main/java/org/aksw/rdfunit/validate/utils/ValidateUtils.java
+++ b/rdfunit-validate/src/main/java/org/aksw/rdfunit/validate/utils/ValidateUtils.java
@@ -87,9 +87,9 @@ public final class ValidateUtils {
 
         loadSchemaDecl(configuration);
 
+        setExcludeSchemata(commandLine, configuration);
         setSchemas(commandLine, configuration);
         setEnrichedSchemas(commandLine, configuration);
-        setExcludeSchemata(commandLine, configuration);
 
         setTestExecutionType(commandLine, configuration);
         setOutputFormats(commandLine, configuration);

--- a/rdfunit-validate/src/test/java/org/aksw/rdfunit/validate/utils/ValidateUtilsTest.java
+++ b/rdfunit-validate/src/test/java/org/aksw/rdfunit/validate/utils/ValidateUtilsTest.java
@@ -20,9 +20,9 @@ public class ValidateUtilsTest {
     public void testGetConfigurationFromArguments() throws ParseException, ParameterException {
         Options cliOptions = ValidateUtils.getCliOptions();
 
-        String args = "";
-        RDFUnitConfiguration configuration = null;
-        CommandLine commandLine = null;
+        String args;
+        RDFUnitConfiguration configuration;
+        CommandLine commandLine;
         CommandLineParser cliParser = new DefaultParser();
 
         // Set two dummy schemas for testing
@@ -174,7 +174,5 @@ public class ValidateUtilsTest {
                 // Do nothing here
             }
         }
-
-
     }
 }


### PR DESCRIPTION

## Description
* Schema exclusion was performed after applying explicitly included schemata, which resulted in confusing behaviour (especially in the default case, excluding owl when explicitly requested)
* in addition the default schemata directory was not copied to the validate module and therefore not available in the CLI case

## How Has This Been Tested?
is covered by the ValidateUtilsTest

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
